### PR TITLE
Switched JCenter repo to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <repository>
             <id>jcenter</id>
             <name>jcenter-bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
         <repository>
             <id>spigot-repo</id>


### PR DESCRIPTION
Switched JCenter repo to https as it refuses non-HTTPS connexion since 2019